### PR TITLE
Fix bug with state loading before the effect runs causing old state to invalidate the optimistic setter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedxm/admin",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedxm/admin",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedxm/admin",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Admin API javascript SDK",
   "author": "ConnectedXM Inc.",
   "type": "module",

--- a/src/mutations/activity/useArchiveActivity.ts
+++ b/src/mutations/activity/useArchiveActivity.ts
@@ -5,7 +5,7 @@ import {
   useConnectedMutation,
 } from "../useConnectedMutation";
 import { GetAdminAPI } from "@src/AdminAPI";
-import { SET_ACTIVITY_QUERY_DATA } from "@src/queries";
+import { ACTIVITIES_QUERY_KEY, SET_ACTIVITY_QUERY_DATA } from "@src/queries";
 
 /**
  * @category Params
@@ -29,6 +29,10 @@ export const ArchiveActivity = async ({
     `/activities/${activityId}/archive`
   );
   if (queryClient && data.status === "ok") {
+    queryClient.invalidateQueries({
+      queryKey: ACTIVITIES_QUERY_KEY(),
+      exact: true,
+    });
     SET_ACTIVITY_QUERY_DATA(queryClient, [activityId], {
       ...data,
       data: { ...data.data, status: ActivityStatus.archived },

--- a/src/mutations/activity/useArchiveActivity.ts
+++ b/src/mutations/activity/useArchiveActivity.ts
@@ -5,7 +5,7 @@ import {
   useConnectedMutation,
 } from "../useConnectedMutation";
 import { GetAdminAPI } from "@src/AdminAPI";
-import { ACTIVITIES_QUERY_KEY, ACTIVITY_QUERY_KEY } from "@src/queries";
+import { ACTIVITY_QUERY_KEY } from "@src/queries";
 
 /**
  * @category Params
@@ -29,7 +29,6 @@ export const ArchiveActivity = async ({
     `/activities/${activityId}/archive`
   );
   if (queryClient && data.status === "ok") {
-    queryClient.invalidateQueries({ queryKey: ACTIVITIES_QUERY_KEY() });
     queryClient.invalidateQueries({
       queryKey: ACTIVITY_QUERY_KEY(activityId),
     });

--- a/src/mutations/activity/useArchiveActivity.ts
+++ b/src/mutations/activity/useArchiveActivity.ts
@@ -1,11 +1,11 @@
-import { ConnectedXMResponse } from "@src/interfaces";
+import { ActivityStatus, ConnectedXMResponse, Activity } from "@src/interfaces";
 import {
   ConnectedXMMutationOptions,
   MutationParams,
   useConnectedMutation,
 } from "../useConnectedMutation";
 import { GetAdminAPI } from "@src/AdminAPI";
-import { ACTIVITY_QUERY_KEY } from "@src/queries";
+import { SET_ACTIVITY_QUERY_DATA } from "@src/queries";
 
 /**
  * @category Params
@@ -23,14 +23,15 @@ export const ArchiveActivity = async ({
   activityId,
   adminApiParams,
   queryClient,
-}: ArchiveActivityParams): Promise<ConnectedXMResponse<null>> => {
+}: ArchiveActivityParams): Promise<ConnectedXMResponse<Activity>> => {
   const connectedXM = await GetAdminAPI(adminApiParams);
-  const { data } = await connectedXM.put<ConnectedXMResponse<null>>(
+  const { data } = await connectedXM.put<ConnectedXMResponse<Activity>>(
     `/activities/${activityId}/archive`
   );
   if (queryClient && data.status === "ok") {
-    queryClient.invalidateQueries({
-      queryKey: ACTIVITY_QUERY_KEY(activityId),
+    SET_ACTIVITY_QUERY_DATA(queryClient, [activityId], {
+      ...data,
+      data: { ...data.data, status: ActivityStatus.archived },
     });
   }
 

--- a/src/mutations/activity/usePublishActivity.ts
+++ b/src/mutations/activity/usePublishActivity.ts
@@ -5,7 +5,7 @@ import {
   useConnectedMutation,
 } from "../useConnectedMutation";
 import { GetAdminAPI } from "@src/AdminAPI";
-import { ACTIVITIES_QUERY_KEY, SET_ACTIVITY_QUERY_DATA } from "@src/queries";
+import { SET_ACTIVITY_QUERY_DATA } from "@src/queries";
 
 /**
  * @category Params
@@ -29,7 +29,6 @@ export const PublishActivity = async ({
     `/activities/${activityId}/publish`
   );
   if (queryClient && data.status === "ok") {
-    queryClient.invalidateQueries({ queryKey: ACTIVITIES_QUERY_KEY() });
     SET_ACTIVITY_QUERY_DATA(queryClient, [activityId], {
       ...data,
       data: { ...data.data, status: ActivityStatus.published },

--- a/src/mutations/activity/usePublishActivity.ts
+++ b/src/mutations/activity/usePublishActivity.ts
@@ -5,7 +5,7 @@ import {
   useConnectedMutation,
 } from "../useConnectedMutation";
 import { GetAdminAPI } from "@src/AdminAPI";
-import { SET_ACTIVITY_QUERY_DATA } from "@src/queries";
+import { ACTIVITIES_QUERY_KEY, SET_ACTIVITY_QUERY_DATA } from "@src/queries";
 
 /**
  * @category Params
@@ -29,6 +29,10 @@ export const PublishActivity = async ({
     `/activities/${activityId}/publish`
   );
   if (queryClient && data.status === "ok") {
+    queryClient.invalidateQueries({
+      queryKey: ACTIVITIES_QUERY_KEY(),
+      exact: true,
+    });
     SET_ACTIVITY_QUERY_DATA(queryClient, [activityId], {
       ...data,
       data: { ...data.data, status: ActivityStatus.published },


### PR DESCRIPTION
### Description

<!-- A brief description of the changes in this PR. -->

### Linear Issues

- closes CXM-[Linear Ticket Number]

### Testing

Besides the automated tests, please manually verify the following:

- [ ] I have manually tested the changes
- [ ] New integration tests have been added (if applicable)

### Semantic Versioning

Indicate the appropriate version bump for this PR:

- [ ] Breaking changes - Major version bump
- [ ] New features / improvements - Minor version bump
- [ ] Bug fixes - Patch version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> ArchiveActivity now returns the updated Activity and updates cache to archived; both publish/archive mutations use exact activities invalidation and set per-activity cache data.
> 
> - **Activities mutations**:
>   - `ArchiveActivity`:
>     - Change response to `ConnectedXMResponse<Activity>` and update request typing.
>     - Invalidate `ACTIVITIES_QUERY_KEY()` with `exact: true` and update per-activity cache via `SET_ACTIVITY_QUERY_DATA` to `status: archived`.
>     - Remove `ACTIVITY_QUERY_KEY` invalidation.
>   - `PublishActivity`:
>     - Invalidate `ACTIVITIES_QUERY_KEY()` with `exact: true`.
>     - Continue updating per-activity cache via `SET_ACTIVITY_QUERY_DATA` to `status: published`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3563780a833a4a3cb6977fa2c19ba47d182218d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->